### PR TITLE
Time to validate query and param with Pipe

### DIFF
--- a/src/common/constant/message.ts
+++ b/src/common/constant/message.ts
@@ -1,4 +1,4 @@
-export const DEFULT_FIND_MESSAGE_LIMIT = 100;
+export const DEFAULT_FIND_MESSAGE_LIMIT = 100;
 
 export const SendOP = {
   DISPATCH_MESSAGE: 0,

--- a/src/common/decorator/user.ts
+++ b/src/common/decorator/user.ts
@@ -1,5 +1,5 @@
 import { createParamDecorator, ExecutionContext } from '@nestjs/common';
 export const ReqUser = createParamDecorator((data: unknown, ctx: ExecutionContext) => {
   const request = ctx.switchToHttp().getRequest();
-  return request.user;
+  return BigInt(request.user.uid);
 });

--- a/src/common/pipe/parse-bigint.pipe.ts
+++ b/src/common/pipe/parse-bigint.pipe.ts
@@ -1,0 +1,15 @@
+import { ArgumentMetadata, BadRequestException, PipeTransform } from '@nestjs/common';
+import { isNil } from 'src/common/util/utils';
+
+export class ParseBigIntPipe implements PipeTransform {
+  public transform(value: any, meta: ArgumentMetadata) {
+    if (isNil(value) || !this.isParsable(value)) {
+      throw new BadRequestException();
+    }
+    return BigInt(value);
+  }
+
+  protected isParsable(value: any) {
+    return ['string', 'number', 'bigint'].includes(typeof value) && new RegExp(/^[0-9]+$/).test(value);
+  }
+}

--- a/src/common/pipe/parse-int.pipe.ts
+++ b/src/common/pipe/parse-int.pipe.ts
@@ -1,0 +1,15 @@
+import { ArgumentMetadata, BadRequestException, PipeTransform } from '@nestjs/common';
+import { isNil } from 'src/common/util/utils';
+
+export class ParseIntPipe implements PipeTransform {
+  public transform(value: any, meta: ArgumentMetadata) {
+    if (isNil(value) || !this.isParsable(value)) {
+      throw new BadRequestException();
+    }
+    return Number(value);
+  }
+
+  protected isParsable(value: any) {
+    return ['string', 'number'].includes(typeof value) && new RegExp(/^[0-9]+$/).test(value);
+  }
+}

--- a/src/common/util/utils.ts
+++ b/src/common/util/utils.ts
@@ -18,3 +18,11 @@ export const isTruthy = (input: unknown): boolean => {
 export const isFalsy = (input: unknown): boolean => {
   return !isTruthy(input);
 };
+
+export const isUndefined = (input: unknown): boolean => {
+  return typeof input === 'undefined';
+};
+
+export const isNil = (input: unknown): boolean => {
+  return isUndefined(input) || input === null;
+};

--- a/src/repository/channel.repository.ts
+++ b/src/repository/channel.repository.ts
@@ -57,10 +57,10 @@ export class ChannelRepository {
       });
   }
 
-  public async findJoinedChannelsByUserId(userId: string) {
+  public async findJoinedChannelsByUserId(userId: bigint) {
     return this.prisma.gh_MemberInChannel
       .findMany({
-        where: { user_id: BigInt(userId) },
+        where: { user_id: userId },
         include: { channel: { include: { _count: { select: { members: true } } } } },
       })
       .then((rst) =>
@@ -90,10 +90,10 @@ export class ChannelRepository {
       });
   }
 
-  public async findChannelMembers(channelId: string) {
+  public async findChannelMembers(channelId: bigint) {
     return this.prisma.gh_MemberInChannel
       .findMany({
-        where: { channel_id: BigInt(channelId) },
+        where: { channel_id: channelId },
         include: {
           user: {
             select: {

--- a/src/repository/message.repository.ts
+++ b/src/repository/message.repository.ts
@@ -19,20 +19,16 @@ export class MessageRepository {
       .then((v) => Message.toSendDto(msg));
   }
 
-  public async getMessagesByQuery(query: IGetChannelMessageQuery & { channelId: string }) {
+  public async getMessagesByQuery(query: { channelId: bigint; before: bigint; limit: number }) {
     return this.mongo
       .collection<Message.Model>(MESSAGE_HISTORY)
       .find({
-        _id: {
-          $lte: query.before ? BigInt(query.before) : SnowFlake.genFake(),
-        },
-        // time: {
-        // 	$gte: // 채팅방에 입장한 시간
-        // },
+        _id: { $lte: query.before },
+        // time: { $gte: 채팅방에 입장한 시간 },
         channel_id: query.channelId,
       })
       .sort('_id', -1)
-      .limit(query.before ? Math.min(Math.abs(+query.before), DEFAULT_FIND_MESSAGE_LIMIT) : DEFAULT_FIND_MESSAGE_LIMIT)
+      .limit(query.limit)
       .toArray()
       .then((msgs) => msgs.map(Message.toSendDto));
   }

--- a/src/repository/message.repository.ts
+++ b/src/repository/message.repository.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectConnection } from '@nestjs/mongoose';
 import { Db } from 'mongodb';
 import { MESSAGE_HISTORY } from 'src/common/constant/database';
-import { DEFULT_FIND_MESSAGE_LIMIT } from 'src/common/constant/message';
+import { DEFAULT_FIND_MESSAGE_LIMIT } from 'src/common/constant/message';
 import { SnowFlake } from 'src/common/util/snowflake';
 import { IGetChannelMessageQuery } from 'src/structure/dto/Channel';
 import { Message } from 'src/structure/message';
@@ -32,7 +32,7 @@ export class MessageRepository {
         channel_id: query.channelId,
       })
       .sort('_id', -1)
-      .limit(query.before ? Math.min(Math.abs(+query.before), DEFULT_FIND_MESSAGE_LIMIT) : DEFULT_FIND_MESSAGE_LIMIT)
+      .limit(query.before ? Math.min(Math.abs(+query.before), DEFAULT_FIND_MESSAGE_LIMIT) : DEFAULT_FIND_MESSAGE_LIMIT)
       .toArray()
       .then((msgs) => msgs.map(Message.toSendDto));
   }

--- a/src/service/channel.service.ts
+++ b/src/service/channel.service.ts
@@ -1,10 +1,6 @@
-import { BadRequestException, Injectable, UnauthorizedException } from '@nestjs/common';
-import { Wrapper } from 'src/common/util/wrapper';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { ChannelRepository } from 'src/repository/channel.repository';
 import { MessageRepository } from 'src/repository/message.repository';
-import { JWTPayload } from 'src/structure/dto/Auth';
-import { IChannelIdParam, IGetChannelMessageQuery } from 'src/structure/dto/Channel';
-import typia from 'typia';
 
 @Injectable()
 export class ChannelService {
@@ -13,38 +9,16 @@ export class ChannelService {
     private readonly messageRepository: MessageRepository,
   ) {}
 
-  public async getJoinedChannels(userId: string) {
+  public async getJoinedChannels(userId: bigint) {
     return { channels: await this.channelRepository.findJoinedChannelsByUserId(userId) };
   }
 
-  public async getChannelMembers(param: IChannelIdParam) {
-    Wrapper.TryOrThrow(
-      () => typia.assertEquals<IChannelIdParam>(param),
-      new BadRequestException({
-        code: '123-123',
-        title: '채널 참가자 조회에 실패했습니다.',
-        message: '요청 형식이 올바르지 않습니다.',
-      }),
-    );
-    return this.channelRepository.findChannelMembers(param.channelId);
+  public async getChannelMembers(channelId: bigint) {
+    return this.channelRepository.findChannelMembers(channelId);
   }
 
-  public async getMessageHistory(dto: JWTPayload & IChannelIdParam & IGetChannelMessageQuery) {
-    Wrapper.TryOrThrow(
-      () => {
-        typia.assertEquals<JWTPayload & IChannelIdParam & IGetChannelMessageQuery>(dto);
-      },
-      new BadRequestException({
-        code: '123-123',
-        title: '대화내역을 불러오지 못했습니다.',
-        message: '요청 형식이 올바르지 않습니다.',
-      }),
-    );
-    const isMemberOfChannel = (await this.channelRepository.findChannelMembers(dto.channelId))
-      .map(({ id }) => id)
-      .includes(dto.uid);
-
-    if (!isMemberOfChannel) {
+  public async getMessageHistory(dto: { userId: bigint; channelId: bigint; before: bigint; limit: number }) {
+    if (!this.isMemberOfChannel(dto.userId, dto.channelId)) {
       throw new UnauthorizedException({
         code: '123-123',
         title: '대화내역을 불러오지 못했습니다.',
@@ -57,5 +31,9 @@ export class ChannelService {
       before: dto.before,
       limit: dto.limit,
     });
+  }
+
+  private async isMemberOfChannel(userId: bigint, channelId: bigint) {
+    return (await this.channelRepository.findChannelMembers(channelId)).map(({ id }) => id).includes(userId.toString());
   }
 }

--- a/src/structure/message.ts
+++ b/src/structure/message.ts
@@ -4,11 +4,11 @@ import { tags } from 'typia';
 export namespace Message {
   export interface Model {
     _id: bigint;
-    channel_id: string;
+    channel_id: bigint;
     content_type: number;
     data: string;
     time: Date;
-    author_id: string;
+    author_id: bigint;
   }
 
   export interface RecvDto {
@@ -28,22 +28,22 @@ export namespace Message {
   export const toModel = (dto: Message.RecvDto & { uid: string }): Message.Model => {
     return {
       _id: SnowFlake.generate(),
-      channel_id: dto.cid,
+      channel_id: BigInt(dto.cid),
       content_type: 0, // temp.
       data: dto.data,
       time: new Date(),
-      author_id: dto.uid,
+      author_id: BigInt(dto.uid),
     };
   };
 
   export const toSendDto = (model: Message.Model): Message.SendDto => {
     return {
       mid: model._id.toString(),
-      cid: model.channel_id,
+      cid: model.channel_id.toString(),
       ctype: model.content_type,
       data: model.data,
       time: model.time.toISOString(),
-      uid: model.author_id,
+      uid: model.author_id.toString(),
     };
   };
 }


### PR DESCRIPTION
기존의 query 또는 parameter를 service layer에서 검증하던 방식을 controller에서 pipe를 통해 검증하고 형변환을 수행하도록 개선하였습니다.

이를 통해 repository에서 값의 유효성을 검사하는 코드를 제거할 수 있었습니다.