### PR TITLE
Go back to BigInt.prototype.toString()

### DIFF
--- a/src/common/util/types.ts
+++ b/src/common/util/types.ts
@@ -1,15 +1,8 @@
 export type Merge<F, S> = {
-  [K in keyof F | keyof S]: K extends keyof S
-    ? S[K]
-    : K extends keyof F
-    ? F[K]
-    : never;
+  [K in keyof F | keyof S]: K extends keyof S ? S[K] : K extends keyof F ? F[K] : never;
 };
 
-export type Flatten<S extends any[], T extends any[] = []> = S extends [
-  infer X,
-  ...infer Y,
-]
+export type Flatten<S extends any[], T extends any[] = []> = S extends [infer X, ...infer Y]
   ? X extends any[]
     ? Flatten<[...X, ...Y], T>
     : Flatten<[...Y], [...T, X]>

--- a/src/structure/message.ts
+++ b/src/structure/message.ts
@@ -18,12 +18,12 @@ export namespace Message {
   }
 
   export interface SendDto {
-    mid: bigint; // Message ID
-    cid: bigint; // Channel ID
+    mid: string; // Message ID
+    cid: string; // Channel ID
     ctype: number; // Message Type {0: Text, 1: Image, 2: File, ...}
     data: string;
     time: string; // ISO 8601
-    uid: bigint;
+    uid: string;
   }
 
   export const toModel = (dto: Message.RecvDto & { uid: string }): Message.Model => {
@@ -40,12 +40,12 @@ export namespace Message {
 
   export const toSendDto = (model: Message.Model): Message.SendDto => {
     return {
-      mid: model._id.toBigInt(),
-      cid: model.channel_id.toBigInt(),
+      mid: model._id.toString(),
+      cid: model.channel_id.toString(),
       ctype: model.content_type,
       data: model.data,
       time: model.time.toISOString(),
-      uid: model.author_id.toBigInt(),
+      uid: model.author_id.toString(),
     };
   };
 }


### PR DESCRIPTION
## 왜 돌아왔는가
socket.io 객체의 `emit()` 메서드를 통해 데이터를 전송하는 경우, 해당 데이터는 interceptor 를 거치지 않고 클라이언트로 전송됩니다.
이 과정에서 `JSON.stringify()`가 BigInt를 직렬화할 수 없어 Runtime Exception이 발생하였습니다.

## 해결 방법
dto로 변환하는 메서드에서 `toString()`을 호출하여 문자열을 반환하도록 수정

## 결론
테스트를 꼭, 잘 하자